### PR TITLE
Allow gloss to copy text and html from the header

### DIFF
--- a/gloss/theme/diazo_resources/gloss.xml
+++ b/gloss/theme/diazo_resources/gloss.xml
@@ -322,12 +322,13 @@
         </h1>
     </replace>
     <replace css:content="header">
-        <div>
-            <xsl:attribute name="class">header-header 
-                <xsl:value-of select="./@class" />
-            </xsl:attribute>
-            <xsl:copy-of select="./*" />
-        </div>
+      <xsl:element name="div">
+	<xsl:copy>
+	    <xsl:copy-of select="@*" />
+	    <xsl:attribute name="class">header-header <xsl:value-of select="./@class" /></xsl:attribute>
+	    <xsl:apply-templates />
+	</xsl:copy>
+      </xsl:element>
     </replace>
     <!-- add gl-message classes to portalMessage -->
     <replace css:content=".portalMessage">


### PR DESCRIPTION
Portlet headers weren't being copied with the following code:
```
            <div>
                <xsl:attribute name="class">header-header <xsl:value-of select="./@class" /></xsl:attribute>
                <xsl:copy-of select="./*"/>
            </div>
```
![image](https://user-images.githubusercontent.com/1830494/44494220-87b18800-a630-11e8-9e03-5d3cf4f929b0.png)

I changed it to:
```

            <xsl:element name="div">
                <xsl:copy>
                    <xsl:copy-of select="@*" />
                    <xsl:attribute name="class">header-header <xsl:value-of select="./@class" /></xsl:attribute>
                    <xsl:apply-templates />
                </xsl:copy>
            </xsl:element>
```
![image](https://user-images.githubusercontent.com/1830494/44494263-b9c2ea00-a630-11e8-96f3-cddf97f969b7.png)

